### PR TITLE
fix: handle position-details section logo url when undefined

### DIFF
--- a/app/position-management/position-details.tsx
+++ b/app/position-management/position-details.tsx
@@ -114,8 +114,8 @@ export default function PositionDetails() {
     const liquidationPercentage = (Number(POSITIONS?.borrowAsset?.tokenDetails[0]?.amount) * 100) / (Number(POSITIONS?.lendAsset?.tokenDetails[0]?.amount) * denominator);
     const liquidationDetails = {
         liquidationPrice: liquidationPrice,
-        assetLogo: POSITIONS?.lendAsset?.tokenDetails[0].logo,
-        assetSymbol: POSITIONS?.lendAsset?.tokenDetails[0].symbol,
+        assetLogo: POSITIONS?.lendAsset?.tokenDetails[0]?.logo,
+        assetSymbol: POSITIONS?.lendAsset?.tokenDetails[0]?.symbol,
         percentage: liquidationPercentage,
         riskFactor: getLiquidationRisk(liquidationPercentage, 50, 80),
     }


### PR DESCRIPTION
## Fix for user position-details section

- Handle position-details section logo url when undefined to avoid client side error