### PR TITLE
fix: add new chain IDs

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -1,3 +1,4 @@
+import { customMetisNetwork } from './config'
 import { ChainId } from './types/chain'
 import { Period, PeriodDisplay } from './types/periodButtons'
 import {
@@ -16,6 +17,7 @@ import {
     avalanche,
     scroll,
     AppKitNetwork,
+    etherlink,
 } from '@reown/appkit/networks'
 
 export type TPlatformWebsiteLinks = {
@@ -278,4 +280,6 @@ export const CHAIN_ID_MAPPER: { [key in ChainId]: AppKitNetwork } = {
     [ChainId.Gnosis]: gnosis,
     [ChainId.Optimism]: optimism,
     [ChainId.Scroll]: scroll,
+    [ChainId.Metis]: customMetisNetwork,
+    [ChainId.Etherlink]: etherlink,
 }

--- a/types/chain.ts
+++ b/types/chain.ts
@@ -14,4 +14,6 @@ export enum ChainId {
     Optimism = 10,
     Scroll = 534351,
     Arbitrum = 42161,
+    Metis = 1088,
+    Etherlink = 42793,
 }


### PR DESCRIPTION
- Introduced new chain IDs for Metis and Etherlink in the ChainId enum.
- Updated CHAIN_ID_MAPPER to include customMetisNetwork and etherlink for improved network support.