### PR TITLE
refactor: rename exclude_morpho_markets to exclude_risky_markets

### DIFF
--- a/app/discover/top-apy-opportunities.tsx
+++ b/app/discover/top-apy-opportunities.tsx
@@ -45,7 +45,7 @@ export default function TopApyOpportunities() {
     const keywordsParam = searchParams.get('keywords') || ''
     const pageParam = searchParams.get('page')
     const sortingParam = searchParams.get('sort')?.split(',') || []
-    const excludeMorphoMarketsParam = searchParams.get('exclude_morpho_markets')
+    const excludeRiskyMarketsParam = searchParams.get('exclude_risky_markets')
     const [keywords, setKeywords] = useState<string>(keywordsParam)
     const debouncedKeywords = useDebounce(keywords, 300)
     const [pagination, setPagination] = useState<PaginationState>({
@@ -164,14 +164,14 @@ export default function TopApyOpportunities() {
             updateSearchParams({ sort: sortParam })
         }
         updateSearchParams({
-            exclude_morpho_markets: positionTypeParam === 'lend' ? 'true' : undefined,
+            exclude_risky_markets: positionTypeParam === 'lend' ? 'true' : undefined,
             protocol_ids: positionTypeParam === 'lend' ? filteredIds : unfilteredIds
         })
     }, [sorting])
 
     useEffect(() => {
-        if (positionTypeParam === 'lend' && excludeMorphoMarketsParam !== 'true') {
-            updateSearchParams({ exclude_morpho_markets: true })
+        if (positionTypeParam === 'lend' && excludeRiskyMarketsParam !== 'true') {
+            updateSearchParams({ exclude_risky_markets: true })
         }
     }, [positionTypeParam])
 
@@ -250,7 +250,7 @@ export default function TopApyOpportunities() {
         const isVault = opportunity.isVault
         const isMorpho = opportunity.platformId.split('-')[0].toLowerCase() === PlatformType.MORPHO
 
-        return excludeMorphoMarketsParam === 'true' ? !(isMorpho && !isVault) : true;
+        return excludeRiskyMarketsParam === 'true' ? !(isMorpho && !isVault) : true;
     }
 
     function handleExcludeMorphoVaultsByPositionType(opportunity: TOpportunityTable) {
@@ -278,7 +278,7 @@ export default function TopApyOpportunities() {
 
         const params = {
             position_type: positionType,
-            exclude_morpho_markets: positionType === 'lend' ? 'true' : undefined,
+            exclude_risky_markets: positionType === 'lend' ? 'true' : undefined,
             protocol_ids: positionType === 'lend' ? filteredIds : unfilteredIds
         }
         updateSearchParams(params)

--- a/components/dropdowns/DiscoverFiltersDropdown.tsx
+++ b/components/dropdowns/DiscoverFiltersDropdown.tsx
@@ -385,7 +385,7 @@ function FilterOptions({
     const updateSearchParams = useUpdateSearchParams()
     const searchParams = useSearchParams()
     const [searchKeyword, setSearchKeyword] = useState<string>('')
-    const [isExcluded, setIsExcluded] = useState(searchParams.get('exclude_morpho_markets') === 'true')
+    const [isExcluded, setIsExcluded] = useState(searchParams.get('exclude_risky_markets') === 'true')
     const positionTypeParam = (searchParams.get('position_type') || 'lend')
     const isMorphoMarketsRisky = useMemo(() => (type === 'protocol' && positionTypeParam === 'lend'), [type, positionTypeParam])
 
@@ -401,14 +401,14 @@ function FilterOptions({
             if (currentProtocolIds.length !== filteredIds.length && positionTypeParam === 'lend') {
                 updateSearchParams({
                     protocol_ids: filteredIds.length ? filteredIds.join(',') : undefined,
-                    exclude_morpho_markets: isExcluded
+                    exclude_risky_markets: isExcluded
                 })
                 return;
             }
         }
 
         updateSearchParams({
-            exclude_morpho_markets: positionTypeParam === 'lend' ? isExcluded : undefined
+            exclude_risky_markets: positionTypeParam === 'lend' ? isExcluded : undefined
         })
     }, [isExcluded, positionTypeParam])
 
@@ -523,11 +523,11 @@ function FilterOptions({
                         label={
                             <Label htmlFor="exclude-morpho-markets">
                                 <TooltipText>
-                                    Exclude Morpho Markets
+                                    Exclude Risky Markets
                                 </TooltipText>
                             </Label>
                         }
-                        content="Exclude Morpho Markets from the list of protocols as they are risky"
+                        content="Supplying to Morpho markets are risky. Excluding them."
                     />
                 </div>
             )}


### PR DESCRIPTION
- Updated state management and search parameters to reflect the new naming convention for excluding risky markets.
- Adjusted related logic and UI elements to ensure consistent behavior and messaging regarding market exclusions.